### PR TITLE
Fix recurrence details order and formatting

### DIFF
--- a/src/Data/RecurrenceData.php
+++ b/src/Data/RecurrenceData.php
@@ -342,6 +342,49 @@ class RecurrenceData implements Arrayable
         ]);
     }
 
+    public function normalizedInterval(): int
+    {
+        return max(1, (int) ($this->interval ?? 1));
+    }
+
+    public function formatIntervalLabel(): ?string
+    {
+        $interval = $this->normalizedInterval();
+
+        if ($interval <= 1) {
+            return null;
+        }
+
+        return "Every {$interval}";
+    }
+
+    public function formatFrequencyLabel(): string
+    {
+        $frequency = strtoupper((string) $this->frequency);
+        $interval = $this->normalizedInterval();
+        $configured = config('filament-recurrence.frequencies', []);
+
+        if ($interval === 1) {
+            return $configured[$frequency] ?? ucfirst(strtolower($frequency));
+        }
+
+        $unitKeys = [
+            'DAILY' => 'daily',
+            'WEEKLY' => 'weekly',
+            'MONTHLY' => 'monthly',
+            'YEARLY' => 'yearly',
+        ];
+
+        $units = __('filament-recurrence::recurrence.frequency_units');
+        $unitKey = $unitKeys[$frequency] ?? null;
+
+        if ($unitKey && is_array($units) && isset($units[$unitKey])) {
+            return ucfirst(trans_choice($units[$unitKey], $interval));
+        }
+
+        return $configured[$frequency] ?? ucfirst(strtolower($frequency));
+    }
+
     public function toHumanReadable(): string
     {
         if (! $this->frequency) {

--- a/src/Infolists/Components/RecurrenceEntry.php
+++ b/src/Infolists/Components/RecurrenceEntry.php
@@ -90,12 +90,12 @@ class RecurrenceEntry extends Entry
 
         $details = [];
 
-        if ($data->frequency) {
-            $details['Frequency'] = ucfirst(strtolower($data->frequency));
+        if ($data->interval && $data->interval > 1) {
+            $details['Interval'] = $data->formatIntervalLabel();
         }
 
-        if ($data->interval && $data->interval > 1) {
-            $details['Interval'] = "Every {$data->interval}";
+        if ($data->frequency) {
+            $details['Frequency'] = $data->formatFrequencyLabel();
         }
 
         if ($data->startDate) {


### PR DESCRIPTION
## Interval = 1 (unchanged)

No interval row; frequency still shows the configured label (e.g. `Weekly`, `Monthly`).

<img width="780" height="101" alt="image" src="https://github.com/user-attachments/assets/fb76d2d3-5413-4b89-aa9f-8291c4ebe239" />

## Interval > 1 (e.g. 2)

- Show **Interval** before **Frequency** so it reads naturally (“Every 2” → “Weeks”).
- Pluralize frequency when interval > 1: `Daily` → `Days`, `Weekly` → `Weeks`, `Monthly` → `Months`, `Yearly` → `Years`.

**Before:**
<img width="889" height="108" alt="image" src="https://github.com/user-attachments/assets/49d95312-cc28-471e-a65b-a7b433c91992" />

**After:**
<img width="808" height="110" alt="image" src="https://github.com/user-attachments/assets/04f8c34f-1f13-4e87-b40f-9f6442aef737" />